### PR TITLE
Edition of form submissions

### DIFF
--- a/docs/docs/how-to/05-forms.md
+++ b/docs/docs/how-to/05-forms.md
@@ -63,7 +63,128 @@ previous submissions. For most cases, it can be made constant.
 
 ## Decrypting form data
 
+Because form data validation cannot occur on the application server,
+due to end-to-end encryption, it has to occur right after decryption.
+
+Here's an example with [Zod](https://zod.dev):
+
+```ts
+import { z } from 'zod'
+
+// Describe the data shape of acceptable responses
+const formDataSchema = z.object({
+  email: z.string().email(),
+  name: z.string(),
+  subscribeToNewsletter: z.boolean(),
+})
+
+const submission = await getSubmissionFromTheApplicationServer()
+const formData = formDataSchema.parse(
+  e2esdkClient.unsealFormData(submission, keychainFingerprint)
+)
+```
+
 ## Files
+
+Files can be encrypted as part of a form submission, but they require
+a bit of preprocessing for sending the encrypted contents to the
+application server, and storing it somewhere for later retrieval.
+
+```ts
+import { encryptFile } from '@socialgouv/e2esdk-crypto'
+
+async function onSubmit(formValues: Record<string, any>) {
+  const namespace = 'my-form'
+  const state = await initializeEncryptedFormLocalState(namespace)
+
+  // 1. encrypt the file contents, obtain a metadata object.
+  const { metadata, encryptedFile } = await encryptFile(
+    state.sodium,
+    formValues.secretDocument[0] // File field values are usually arrays
+  )
+
+  // 2. Replace the File object in the form values with its metadata
+  formValues.secretDocument = metadata
+
+  // 3. Encrypt the form data, including metadata
+  const submission = encryptFormData(formValues, state)
+
+  // 4. Send it all to the application server
+  await sendEncryptedFormDataAndFilesToTheApplicationServer(
+    submission,
+    encryptedFile
+  )
+}
+```
+
+:::tip
+
+The metadata contains a `hash` property, which is the SHA-512 of the ciphertext.
+
+You may use it for data integrity verification, and/or for content addressing.
+
+:::
+
+At decryption time, you can use the `fileMetadataSchema` to validate metadata
+objects:
+
+```ts
+import { fileMetadataSchema } from '@socialgouv/e2esdk-crypto'
+
+const formDataSchema = z.object({
+  secretDocument: fileMetadataSchema,
+})
+```
+
+The decrypted metadata lets your UI display:
+
+- The file name
+- The size in bytes
+- Its MIME type
+- The last modified date
+
+This can guide your users into selecting which file to download.
+
+You can then download the encrypted contents, and use the key in the metadata to decrypt it:
+
+```ts
+import {
+  decryptFileContents,
+  FileMetadata,
+  Sodium,
+} from '@socialgouv/e2esdk-crypto'
+
+async function downloadAndDecryptFile(sodium: Sodium, metadata: FileMetadata) {
+  // Fetch encrypted file contents from your application server, eg:
+  const res = await fetch(`/encryped-file?hash=${metadata.hash}`)
+  const ciphertext = new Uint8Array(await (await res.blob()).arrayBuffer())
+  const cleartext = decryptFileContents(sodium, ciphertext, {
+    algorithm: 'secretBox',
+    key: sodium.from_base64(metadata.key),
+  })
+  return new File([cleartext], metadata.name, {
+    type: metadata.type,
+    lastModified: metadata.lastModified,
+  })
+}
+
+// This may come handy to save the file on your computer:
+function saveFile(file: File) {
+  const link = document.createElement('a')
+  link.setAttribute('href', URL.createObjectURL(file))
+  link.setAttribute('download', file.name)
+  link.click()
+  URL.revokeObjectURL(link.href)
+}
+```
+
+:::tip
+
+For a more detailed example of form encryption with files, check out the
+[contact-forms](https://github.com/SocialGouv/e2esdk/blob/4dab716578e8aabfdf32b55e67173976854cb21e/examples/fullstack/contact-forms)
+example in the e2esdk repository.
+
+:::
 
 ## Editing responses
 

--- a/examples/fullstack/contact-forms/src/hasura/metadata/databases/app/tables/public_contact_form_submissions.yaml
+++ b/examples/fullstack/contact-forms/src/hasura/metadata/databases/app/tables/public_contact_form_submissions.yaml
@@ -58,3 +58,26 @@ select_permissions:
         - proof_of_identity
         - identity_photo
       filter: {}
+update_permissions:
+  - role: public
+    permission:
+      columns:
+        - age
+        - contact_me
+        - email
+        - first_name
+        - last_name
+        - message
+        - phone_number
+        - subject
+        - created_at
+        - proof_of_identity
+        - identity_photo
+        - public_key
+        - sealed_secret
+        - signature
+      filter:
+        public_key:
+          _ceq:
+            - public_key
+      check: {}

--- a/examples/fullstack/contact-forms/src/lib/contact-form.tsx
+++ b/examples/fullstack/contact-forms/src/lib/contact-form.tsx
@@ -19,17 +19,22 @@ import {
   useToast,
 } from '@chakra-ui/react'
 import {
+  decryptFormForEdition,
   encryptFile,
   encryptFormData,
+  fileMetadataSchema,
   initializeEncryptedFormLocalState,
+  isEncryptedFormLocalStatePersisted,
+  persistEncryptedFormLocalState,
 } from '@socialgouv/e2esdk-crypto'
 import request, { gql } from 'graphql-request'
+import Link from 'next/link'
 import prettyBytes from 'pretty-bytes'
 import React from 'react'
 import { useForm } from 'react-hook-form'
 import { FiSend, FiX } from 'react-icons/fi'
 import { z } from 'zod'
-import { uploadFiles } from './files'
+import { downloadAndDecryptFile, uploadFiles } from './files'
 
 const formSchema = z.object({
   subject: z.string(),
@@ -62,25 +67,41 @@ type InsertResponseData = {
   }
 }
 
+type UpdateResponseData = {
+  updated: null | {
+    id: string
+  }
+}
+
+const LAST_SUBMISSION_ID_STORAGE_KEY = 'e2esdk:contact-forms:lastSubmissionId'
+
 // --
 
 export type ContactFormProps = {
   submissionBucketId: string
   publicKey: Uint8Array
+  editLink?: string
 }
 
 export const ContactForm: React.FC<ContactFormProps> = ({
   submissionBucketId,
   publicKey,
+  editLink,
 }) => {
   const {
     register,
     handleSubmit,
     watch,
-    resetField,
+    setValue,
     formState: { isSubmitting },
     reset: resetForm,
   } = useForm<FormValues>()
+
+  const currentlyEditedSubmissionId = useEdition(
+    submissionBucketId,
+    publicKey,
+    resetForm
+  )
 
   const inputFileStyles = {
     '::file-selector-button': {
@@ -145,31 +166,57 @@ export const ContactForm: React.FC<ContactFormProps> = ({
         publicKey: metadata.publicKey,
         ...encrypted,
       }
-      const res = await request<InsertResponseData>(
-        'http://localhost:4002/v1/graphql', // todo: Use env
-        SUBMIT_CONTACT_FORM_MUTATION,
-        variables
-      )
-      if (res.inserted?.id) {
-        toast({
-          status: 'success',
-          title: 'Thanks!',
-          description: (
-            <>
-              Your message has been sent.
-              {values.contactMe && (
-                <>
-                  <br />
-                  We will contact you back shortly.
-                </>
-              )}
-            </>
-          ),
-        })
-        resetForm()
+      if (currentlyEditedSubmissionId === null) {
+        const res = await request<InsertResponseData>(
+          'http://localhost:4002/v1/graphql', // todo: Use env
+          SUBMIT_CONTACT_FORM_MUTATION,
+          variables
+        )
+        if (res.inserted?.id) {
+          toast({
+            status: 'success',
+            title: 'Thanks!',
+            description: (
+              <>
+                Your message has been sent.
+                {values.contactMe && (
+                  <>
+                    <br />
+                    We will contact you back shortly.
+                  </>
+                )}
+              </>
+            ),
+          })
+          persistEncryptedFormLocalState(state, submissionBucketId)
+          window.localStorage.setItem(
+            LAST_SUBMISSION_ID_STORAGE_KEY,
+            res.inserted.id
+          )
+        }
+      } else {
+        // @ts-ignore
+        delete variables.submissionBucketId
+        const res = await request<UpdateResponseData>(
+          'http://localhost:4002/v1/graphql', // todo: Use env
+          EDIT_CONTACT_FORM_MUTATION,
+          {
+            ...variables,
+            id: currentlyEditedSubmissionId,
+          }
+        )
+        if (res.updated?.id) {
+          toast({
+            status: 'success',
+            title: 'Thanks!',
+            description: <>Your message has been updated.</>,
+          })
+        } else {
+          console.dir(res)
+        }
       }
     },
-    [publicKey, submissionBucketId, toast, resetForm]
+    [publicKey, submissionBucketId, toast, currentlyEditedSubmissionId]
   )
   const proofOfIdentity = watch('proofOfIdentity')?.[0]
   const identityPhoto = watch('identityPhoto')?.[0]
@@ -180,6 +227,9 @@ export const ContactForm: React.FC<ContactFormProps> = ({
       <Text fontSize="sm" color="gray.600" _dark={{ color: 'gray.400' }} mt={1}>
         All provided data is end-to-end encrypted.
       </Text>
+      {editLink && currentlyEditedSubmissionId !== null && (
+        <Link href={editLink}>Edit last submission</Link>
+      )}
       <form onSubmit={handleSubmit(onSubmit)}>
         <SimpleGrid columns={{ base: 1, md: 2 }} gap={8} mt={8}>
           <Stack spacing={4}>
@@ -205,17 +255,13 @@ export const ContactForm: React.FC<ContactFormProps> = ({
                 type="file"
                 accept=".pdf"
                 sx={inputFileStyles}
-                {...register('proofOfIdentity', {
-                  setValueAs(value) {
-                    return value?.[0] ?? null
-                  },
-                })}
+                {...register('proofOfIdentity')}
               />
               <FormHelperText display="flex" alignItems="center" gap={2}>
                 {proofOfIdentity ? (
                   <>
                     <Button
-                      onClick={() => resetField('proofOfIdentity')}
+                      onClick={() => setValue('proofOfIdentity', undefined)}
                       size="xs"
                       leftIcon={
                         <Icon
@@ -227,7 +273,7 @@ export const ContactForm: React.FC<ContactFormProps> = ({
                       colorScheme="red"
                       variant="ghost"
                     >
-                      Remove
+                      Remove proof of identity
                     </Button>
                     {prettyBytes(proofOfIdentity.size)}
                   </>
@@ -251,7 +297,7 @@ export const ContactForm: React.FC<ContactFormProps> = ({
                   <>
                     <Flex alignItems="center" gap={2} mb={2}>
                       <Button
-                        onClick={() => resetField('identityPhoto')}
+                        onClick={() => setValue('identityPhoto', undefined)}
                         size="xs"
                         leftIcon={
                           <Icon
@@ -263,7 +309,7 @@ export const ContactForm: React.FC<ContactFormProps> = ({
                         colorScheme="red"
                         variant="ghost"
                       >
-                        Remove
+                        Remove ID photo
                       </Button>
                       {prettyBytes(identityPhoto.size)}
                     </Flex>
@@ -389,6 +435,151 @@ const SUBMIT_CONTACT_FORM_MUTATION = gql`
       }
     ) {
       id
+    }
+  }
+`
+
+const EDIT_CONTACT_FORM_MUTATION = gql`
+  mutation EditContactForm(
+    $id: Int!
+    # Metadata
+    $signature: String!
+    $sealedSecret: String!
+    $publicKey: String!
+    # Encrypted fields
+    $subject: String
+    $message: String
+    $firstName: String
+    $lastName: String
+    $age: String
+    $contactMe: String
+    $email: String
+    $phoneNumber: String
+    $proofOfIdentity: String
+    $identityPhoto: String
+  ) {
+    updated: update_contactFormSubmissions_by_pk(
+      pk_columns: { id: $id }
+      _set: {
+        # Updated metadata
+        signature: $signature
+        # Note that the sealed secret itself doesn't change,
+        # but is re-encrypted for every submission, so its
+        # ciphertext changes, which is computed in the signature.
+        sealedSecret: $sealedSecret
+        publicKey: $publicKey
+        # Updated encrypted fields
+        subject: $subject
+        message: $message
+        firstName: $firstName
+        lastName: $lastName
+        age: $age
+        contactMe: $contactMe
+        email: $email
+        phoneNumber: $phoneNumber
+        proofOfIdentity: $proofOfIdentity
+        identityPhoto: $identityPhoto
+      }
+    ) {
+      id
+    }
+  }
+`
+
+// --
+
+function useEdition(
+  submissionBucketId: string,
+  formPublicKey: Uint8Array,
+  onLoaded: (values: FormValues) => void
+) {
+  const [submissionId, setSubmissionId] = React.useState<number | null>(null)
+  React.useEffect(() => {
+    // First, check if there is a valid persisted state
+    // (last submission ID + cryptographic state)
+    const submissionId = parseInt(
+      window.localStorage.getItem(LAST_SUBMISSION_ID_STORAGE_KEY) ?? ''
+    )
+    if (
+      !isEncryptedFormLocalStatePersisted(submissionBucketId) ||
+      !submissionId
+    ) {
+      return
+    }
+    loadFormState(submissionId, submissionBucketId, formPublicKey)
+      .then(onLoaded)
+      .then(() => setSubmissionId(submissionId))
+      .catch(console.error)
+  }, [submissionBucketId, formPublicKey, onLoaded])
+  return submissionId
+}
+
+async function loadFormState(
+  submissionId: number,
+  submissionBucketId: string,
+  formPublicKey: Uint8Array
+): Promise<FormValues> {
+  const state = await initializeEncryptedFormLocalState(
+    submissionBucketId,
+    formPublicKey
+  )
+  const { submission } = await request<{
+    submission: SubmitContactFormVariables
+  }>(
+    'http://localhost:4002/v1/graphql', // todo: Use env
+    GET_CONTACT_FORM_SUBMISSION,
+    {
+      id: submissionId,
+    }
+  )
+  const { publicKey, sealedSecret, signature, ...encrypted } = submission
+  const decrypted = decryptFormForEdition(
+    {
+      metadata: {
+        publicKey,
+        sealedSecret,
+        signature,
+      },
+      encrypted,
+    },
+    state
+  )
+  // Re-hydrate files before parsing
+  const identityPhoto = fileMetadataSchema.safeParse(decrypted.identityPhoto)
+  if (identityPhoto.success) {
+    decrypted.identityPhoto = [
+      await downloadAndDecryptFile(state.sodium, identityPhoto.data),
+    ]
+  }
+  const proofOfIdentity = fileMetadataSchema.safeParse(
+    decrypted.proofOfIdentity
+  )
+  if (proofOfIdentity.success) {
+    decrypted.proofOfIdentity = [
+      await downloadAndDecryptFile(state.sodium, proofOfIdentity.data),
+    ]
+  }
+  return formSchema.parse(decrypted)
+}
+
+const GET_CONTACT_FORM_SUBMISSION = gql`
+  query ContactFormSubmission($id: Int!) {
+    submission: contactFormSubmissions_by_pk(id: $id) {
+      # Metadata
+      signature
+      sealedSecret
+      publicKey
+      # Encrypted fields
+      subject
+      message
+      firstName
+      lastName
+      age
+      contactMe
+      email
+      phoneNumber
+      proofOfIdentity
+      identityPhoto
     }
   }
 `

--- a/examples/fullstack/contact-forms/src/pages/_app.tsx
+++ b/examples/fullstack/contact-forms/src/pages/_app.tsx
@@ -10,7 +10,7 @@ import dynamic from 'next/dynamic'
 import Head from 'next/head'
 
 const e2esdkClient = new Client({
-  serverURL: 'http://localhost:4003',
+  serverURL: 'https://localhost:4003',
   serverSignaturePublicKey: 'gsE7B63ETtNDIzAwXEp3X1Hv12WCKGH6h7brV3U9NKE',
 })
 const reactQueryClient = new QueryClient()

--- a/packages/api/src/schemas/encodings.ts
+++ b/packages/api/src/schemas/encodings.ts
@@ -25,6 +25,7 @@ export const PayloadType = {
   string: 'txt', // string
   number: 'num', // number
   boolean: 'bool', // boolean
+  date: 'date', // Date objects
   json: 'json', // other
 } as const
 

--- a/packages/crypto/src/form/encryption.ts
+++ b/packages/crypto/src/form/encryption.ts
@@ -24,7 +24,7 @@ import { EncryptedFormLocalState } from './state'
 const encryptedFieldSchema = z
   .string()
   .regex(
-    /^[0-7][0-9a-f]{7}:v1\.secretBox\.(bin|txt|num|bool|json)\.[\w-]{32}\.[\w-]{22,}$/
+    /^[0-7][0-9a-f]{7}:v1\.secretBox\.(bin|txt|num|bool|date|json)\.[\w-]{32}\.[\w-]{22,}$/
   )
   .transform(value => {
     const [context, ciphertext] = value.split(':')

--- a/packages/crypto/src/form/form.test.ts
+++ b/packages/crypto/src/form/form.test.ts
@@ -1,0 +1,127 @@
+import { base64UrlDecode, base64UrlEncode } from '../shared/codec'
+import { ready, sodium } from '../sodium/sodium'
+import {
+  decryptFormData,
+  decryptFormForEdition,
+  encryptFormData,
+} from './encryption'
+import {
+  clearEncryptedFormLocalState,
+  generateEncryptedFormLocalState,
+  initializeEncryptedFormLocalState,
+  isEncryptedFormLocalStatePersisted,
+  listPersistedEncryptedFormLocalStates,
+  persistEncryptedFormLocalState,
+} from './state'
+
+const localStorageMock = (function () {
+  let store: Record<string, string> = {}
+  return {
+    get length() {
+      return Object.keys(store).length
+    },
+    getItem(key: string) {
+      return store[key]
+    },
+    setItem(key: string, value: string) {
+      store[key] = value
+    },
+    clear() {
+      store = {}
+    },
+    removeItem(key: string) {
+      delete store[key]
+    },
+    key(index: number) {
+      return Object.keys(store)[index]
+    },
+    getAll() {
+      return store
+    },
+  }
+})()
+
+const TEST_KEY_PAIR = {
+  publicKey: base64UrlDecode('QV4W8xDJLzmdlnFFobppKWQb2WbOEAGR2lrPQogNXQA'),
+  privateKey: base64UrlDecode('bd0d1TLbthKjfc5ZiIdUu5cQ88LHVHcSq8-v9wIfMW0'),
+}
+
+const TEST_DATA = {
+  firstName: 'James',
+  lastName: 'Brown',
+  age: 73,
+  dateOfBirth: new Date('1933-05-03'),
+  isAlive: false,
+  occupations: ['singer', 'musician', 'record producer', 'band leader'],
+  children: {
+    min: 9,
+    max: 13,
+  },
+}
+
+beforeAll(async () => {
+  Object.defineProperty(window, 'localStorage', { value: localStorageMock })
+  await ready
+  const publicKey = sodium.crypto_scalarmult_base(TEST_KEY_PAIR.privateKey)
+  expect(publicKey).toEqual(TEST_KEY_PAIR.publicKey)
+})
+
+describe('forms', () => {
+  test('state init', async () => {
+    const state = await generateEncryptedFormLocalState(TEST_KEY_PAIR.publicKey)
+    expect(state.formPublicKey).toEqual(TEST_KEY_PAIR.publicKey)
+    expect(state.keyDerivationContext).toEqual('QV4W8xDJ')
+    expect(state.sodium.ready).resolves.toBe(void 0)
+    // States are not persisted by default
+    expect(listPersistedEncryptedFormLocalStates()).toEqual([])
+  })
+
+  test('state retrieval', async () => {
+    const namespace = 'namespace'
+    const state1 = await generateEncryptedFormLocalState(
+      TEST_KEY_PAIR.publicKey
+    )
+    persistEncryptedFormLocalState(state1, namespace)
+    expect(
+      window.localStorage.getItem('e2esdk:forms:localState:namespace')
+    ).toEqual(base64UrlEncode(state1.mainSecret))
+    const state2 = await initializeEncryptedFormLocalState(
+      namespace,
+      TEST_KEY_PAIR.publicKey
+    )
+    expect(state2.mainSecret).toEqual(state1.mainSecret)
+    expect(state2.formPublicKey).toEqual(state1.formPublicKey)
+    expect(state2.identity.privateKey).toEqual(state1.identity.privateKey)
+    expect(state2.keyDerivationSecret).toEqual(state1.keyDerivationSecret)
+    expect(listPersistedEncryptedFormLocalStates()).toEqual([namespace])
+    expect(isEncryptedFormLocalStatePersisted(namespace)).toBe(true)
+  })
+
+  test('state cleanup', async () => {
+    const namespace = 'namespace'
+    const state = await generateEncryptedFormLocalState(TEST_KEY_PAIR.publicKey)
+    persistEncryptedFormLocalState(state, namespace)
+    expect(listPersistedEncryptedFormLocalStates()).toEqual([namespace])
+    expect(isEncryptedFormLocalStatePersisted(namespace)).toBe(true)
+    clearEncryptedFormLocalState(namespace)
+    expect(listPersistedEncryptedFormLocalStates()).toEqual([])
+    expect(isEncryptedFormLocalStatePersisted(namespace)).toBe(false)
+  })
+
+  test('encrypting data, decryption via private key', async () => {
+    const state = await generateEncryptedFormLocalState(TEST_KEY_PAIR.publicKey)
+    const submission = encryptFormData(TEST_DATA, state)
+    const decrypted = decryptFormData(state.sodium, submission, {
+      algorithm: 'sealedBox',
+      ...TEST_KEY_PAIR,
+    })
+    expect(decrypted).toEqual(TEST_DATA)
+  })
+
+  test('encrypting data, decryption via local state (edition)', async () => {
+    const state = await generateEncryptedFormLocalState(TEST_KEY_PAIR.publicKey)
+    const submission = encryptFormData(TEST_DATA, state)
+    const decrypted = decryptFormForEdition(submission, state)
+    expect(decrypted).toEqual(TEST_DATA)
+  })
+})

--- a/packages/crypto/src/form/state.ts
+++ b/packages/crypto/src/form/state.ts
@@ -183,6 +183,45 @@ export function clearEncryptedFormLocalState(namespace: string) {
   window.localStorage.removeItem(storageKey(namespace))
 }
 
+/**
+ * List the namespaces available for retrieving encrypted form states.
+ *
+ * Warning: this method may be costly if there is a lot of items stored in
+ * the origin's localStorage (lots of keys, value sizes don't matter).
+ */
+export function listPersistedEncryptedFormLocalStates() {
+  if (typeof window !== 'object') {
+    return []
+  }
+  const numItems = window.localStorage.length
+  const namespaces: string[] = []
+  const storageKeyPrefix = storageKey('')
+  for (let i = 0; i < numItems; ++i) {
+    const key = window.localStorage.key(i)
+    if (key?.startsWith(storageKeyPrefix)) {
+      namespaces.push(key.slice(storageKeyPrefix.length))
+    }
+  }
+  return namespaces
+}
+
+/**
+ * Check if a form state can be retrieved for edition.
+ *
+ * Because {@link initializeEncryptedFormLocalState `initializeEncryptedFormLocalState`}
+ * will generate a new state if it fails to find one to retrieve,
+ * a way to check if edition is possible may be required beforehand.
+ *
+ * @param namespace The localStorage namespace to lookup
+ * @returns true if there is a persisted state, false otherwise.
+ */
+export function isEncryptedFormLocalStatePersisted(namespace: string) {
+  if (typeof window !== 'object') {
+    return false
+  }
+  return Boolean(window.localStorage.getItem(storageKey(namespace)))
+}
+
 // --
 
 function deriveState(

--- a/packages/crypto/src/sodium/encryption.ts
+++ b/packages/crypto/src/sodium/encryption.ts
@@ -108,6 +108,11 @@ export function encrypt<DataType>(
         payloadType: PayloadType.boolean,
         payload: boolToBytes(input),
       }
+    : input instanceof Date
+    ? {
+        payloadType: PayloadType.date,
+        payload: input.toISOString(),
+      }
     : {
         payloadType: PayloadType.json,
         payload: sodium.from_string(JSON.stringify(input)),
@@ -301,6 +306,9 @@ function decodePayload(
   }
   if (payloadType === PayloadType.boolean) {
     return bytesToBool(plaintext)
+  }
+  if (payloadType === PayloadType.date) {
+    return new Date(sodium.to_string(plaintext))
   }
   if (payloadType === PayloadType.json) {
     return secureJSON.parse(sodium.to_string(plaintext).trim())

--- a/packages/crypto/src/sodium/files.ts
+++ b/packages/crypto/src/sodium/files.ts
@@ -15,7 +15,7 @@ export const fileMetadataSchema = z.object({
   /** MIME type */
   type: z.string(),
 
-  /** SHA-512, hex-encoded */
+  /** SHA-512 of the ciphertext, hex-encoded */
   hash: z.string().regex(/^[0-9a-f]{128}$/i),
 
   /** Symmetric key to encrypt/decrypt file contents */


### PR DESCRIPTION
To edit form submissions, the author must be able to decrypt the responses they sent, in order to hydrate the form UI with initial values.

Each form field is encrypted with a symmetric key derived from a key derivation secret. In the submission bundle, this key derivation secret is encrypted with the form public key, and sent along the encrypted form data as metadata. Owners of the form private key already had the ability to decrypt this key derivation secret, and decrypt each form field by performing the same key derivation as when encryption occurred.

Form data authors don't have access to the form private key, and so must obtain the key derivation secret by other means. It is derived from a main secret, which is persisted in localStorage when later edition is desirable.
The main secret also derives the identity signature key pair that authenticates the author in a particular context.

The application server receiving edits can then verify the signature against the initial submission's public key, to authenticate the author.

Tasks:

- [x] Cryptographic implementation
- [x] Tests
- [x] Documentation